### PR TITLE
[WIP] Trying to solve the gradle issue (#2)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip


### PR DESCRIPTION
**Description**
Trying to solve issue #2 related to the Gradle builder.

**Things done**
* Update gradle wrapper to version 6.7 (Successfully)
  * Change the URL in gradle/wrapper/gradle-wrapper.properties
to https\://services.gradle.org/distributions/gradle-6.7-all.zip

**Dockerfile for testing**
https://gist.github.com/ShamrockLee/9d75e4b91d575dec19f96d8f50ee4fb9

**Current Issue**
```
FAILURE: Build failed with an exception.

* Where:
Build file '/opt/gdlde/gdlde/build.gradle' line: 2

* What went wrong:
A problem occurred evaluating project ':gdlde'.
> Failed to apply plugin 'org.akhikhl.wuff.eclipse-ide-app'.
   > Plugin with id 'osgi' not found.

```
